### PR TITLE
Removed number highlighting inside identifiers

### DIFF
--- a/syntax/bminor.vim
+++ b/syntax/bminor.vim
@@ -31,6 +31,7 @@ syn keyword bminorBoolean true false
 syn match bminorInteger "\v[0-9]+"
 syn match bminorString  '\v\"([^\"\n\\]|\\\n|\\.){0,255}\"'
 syn match bminorChar "\v\'([^\\\']|\\.|�)\'"
+syn match bminorIdent "[a-zA-Z_][a-zA-Z0-9_]*"
 
 " Operators  TODO * and / get mixed up w comments
 syntax match bminorOperator "\v\*"
@@ -50,7 +51,7 @@ syntax match bminorOperator "\v\|\|"
 
 " Statement
 " just doing blocks for statements
-syn region bminorStatement start="{" end="}" fold transparent contains=bminorNumber,bminorStatement,bminorOperator,bminorInteger,bminorComment,bminorAction,bminorBoolean,bminorType,bminorChar,bminorString,bminorConditional,bminorFor
+syn region bminorStatement start="{" end="}" fold transparent contains=bminorNumber,bminorStatement,bminorOperator,bminorInteger,bminorComment,bminorAction,bminorBoolean,bminorType,bminorChar,bminorString,bminorConditional,bminorFor,bminorIdent
 
 
 " C++ style comment
@@ -75,3 +76,6 @@ hi def link bminorFor Repeat
 hi def link bminorConditional Conditional
 hi def link bminorAction Keyword
 hi def link bminorStatement Statement
+" Make this bminorIdent Identifer if you want your identifiers highlighted
+hi def link bminorIdent None
+


### PR DESCRIPTION
Numbers should no longer be highlighted within idents; also if someone wants to have their idents highlighted they can add the line I mention at the end of bminor.vim.

![image](https://user-images.githubusercontent.com/56324444/95236228-a9503800-07d4-11eb-9182-0186097554f5.png)
