### PR TITLE
added map keyword, removed auto keyword

### DIFF
--- a/syntax/bminor.vim
+++ b/syntax/bminor.vim
@@ -28,10 +28,6 @@ syn keyword bminorBoolean true false
 
 " === Matches ===
 
-syn match bminorString  '\v\"([^\"\n\\]|\\\n|\\.){0,255}\"'
-syn match bminorChar "\v\'([^\\\']|\\.|�)\'"
-syn match bminorIdent "[a-zA-Z_][a-zA-Z0-9_]*"
-
 " Operators  TODO * and / get mixed up w comments
 syntax match bminorOperator "\v\*"
 syntax match bminorOperator "/"
@@ -46,7 +42,11 @@ syntax match bminorOperator "\v\&\&"
 syntax match bminorOperator "\v\|\|"
 syntax match bminorOperator "\v\^"
 
+" Constants & identifiers
+syn match bminorString  '\v\"([^\"\n\\]|\\\n|\\.){0,255}\"'
+syn match bminorChar "\v\'([^\\\']|\\.|�)\'"
 syn match bminorInteger "\v(\+|-)?[0-9]+"
+syn match bminorIdent "[a-zA-Z_][a-zA-Z0-9_]*"
 
 " === Regions ===
 
@@ -79,4 +79,3 @@ hi def link bminorAction Keyword
 hi def link bminorStatement Statement
 " Make this bminorIdent Identifer if you want your identifiers highlighted
 hi def link bminorIdent None
-

--- a/syntax/bminor.vim
+++ b/syntax/bminor.vim
@@ -28,7 +28,6 @@ syn keyword bminorBoolean true false
 
 " === Matches ===
 
-syn match bminorInteger "\v[0-9]+"
 syn match bminorString  '\v\"([^\"\n\\]|\\\n|\\.){0,255}\"'
 syn match bminorChar "\v\'([^\\\']|\\.|�)\'"
 syn match bminorIdent "[a-zA-Z_][a-zA-Z0-9_]*"
@@ -46,6 +45,8 @@ syntax match bminorOperator "\v\!"
 syntax match bminorOperator "\v\&\&"
 syntax match bminorOperator "\v\|\|"
 syntax match bminorOperator "\v\^"
+
+syn match bminorInteger "\v(\+|-)?[0-9]+"
 
 " === Regions ===
 

--- a/syntax/bminor.vim
+++ b/syntax/bminor.vim
@@ -18,7 +18,7 @@ endif
 
 " === Keywords ===
 
-syn keyword bminorType array auto boolean char integer string void
+syn keyword bminorType array boolean char integer string void map
 syn keyword bminorFunction function
 syn keyword bminorAction print return
 syn keyword bminorConditional else if


### PR DESCRIPTION
2020 B-Minor specification no longer has the `auto` keyword
#7: Added the `map` keyword. No extra special features, since its syntax is analogous to arrays.
Can hold off on adding this in until later, since the current 2020 course did not mention `map` in its project guide.